### PR TITLE
add semantic-release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || 'refs/heads/beta' || github.ref == 'refs/heads/alpha'
     needs: build
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,3 +27,19 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Make binaries
+        uses: sosedoff/actions/golang-build@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx -p @semantic-release/changelog -p @semantic-release/git -p semantic-release semantic-release

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
         uses: sosedoff/actions/golang-build@master
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,27 @@
+{
+    "branches": [
+        "master",
+        {
+            "name": "beta",
+            "prerelease": true
+        },
+        {
+            "name": "alpha",
+            "prerelease": true
+        }
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/changelog",
+        "@semantic-release/git",
+        ["@semantic-release/github", {
+                "assets": [
+                    {
+                        "path": "$GITHUB_WORKSPACE/.release/*"
+                    }
+                ]
+            }
+        ]
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# [1.0.0](https://github.com/Silthus/go-generator-cli/compare/v0.2.0...v1.0.0) (2021-09-17)
+
+
+### chore
+
+* **release:** setup semantic-release ([d34ef0f](https://github.com/Silthus/go-generator-cli/commit/d34ef0fcbe1525f3629ec52458254bd4de167bd7))
+
+
+### BREAKING CHANGES
+
+* **release:** all commits now require the conventional commit format


### PR DESCRIPTION
Added semantic-release workflow to automatically publish releases and versions on push to the following branches:
- `master`
- `beta`
- `alpha`

The commit messages need to be in the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/) for this to work.
The commit https://github.com/Silthus/go-generator-cli/commit/d34ef0fcbe1525f3629ec52458254bd4de167bd7 bumps to version to 1.0.0