### PR TITLE
chore(release): add automatic version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,14 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - run: go build
+      - name: Dry run to get the next release version
+        id: version
+        uses: go-semantic-release/action@v1
+        with:
+          dry: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: go build -ldflags="-X 'main.version=${{ steps.version.outputs.VERSION }}'" 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/main.go
+++ b/main.go
@@ -8,11 +8,19 @@ import (
 	"os"
 )
 
+var version = ""
+
 func main() {
 	ctx := context.Background()
-	aulogging.Logger.Ctx(ctx).Info().Print("welcome to go-generator-cli")
+
+	if version != "" {
+		aulogging.Logger.Ctx(ctx).Info().Print("welcome to go-generator-cli version: " + version)
+	} else {
+		aulogging.Logger.Ctx(ctx).Info().Print("welcome to go-generator-cli")
+	}
+
 	if internal.Perform(ctx) {
-		aulogging.Logger.Ctx(ctx).Info().Print("success")
+		aulogging.Logger.Ctx(ctx).Info().Print("success") 
 		os.Exit(0)
 	} else {
 		aulogging.Logger.Ctx(ctx).Error().Print("there were errors, return code is 1")


### PR DESCRIPTION
I wasn't able to perfectly test it as my forked repository does not have any releases yet.

I've added a step to the workflow that dry-runs the semantic release. This step automatically sets the version variable.

The version variable is being used by the go build command: 
```run: go build -ldflags="-X 'main.version=${{ steps.version.outputs.VERSION }}'" ```

This injects the variable into the variable declared in the `main.go`. 

I've thought about having a separate file `version.go` or something like that, but I've opted against it. It might make sense in the future if you want to enable the customary `--version` flag. 